### PR TITLE
ci: test and check all three crates, not just one

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check
+      - run: cargo check --workspace
 
   test:
     name: Test Suite
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test
+      - run: cargo test --workspace
 
   lints:
     name: Lints
@@ -25,4 +25,4 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --all -- --check
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
- Running `cargo test` without `--workspace` covers only the `hexora` crate but not `hexora_io`.

- Running `cargo check` without `--workspace` covers only `hexora` and `hexora_io` but not `hexora_py`.

- `cargo clippy`: same as with `cargo check`.

This PR adds `--workspace` to all three invocations so it covers all three crates.
