### PR TITLE
tests: Arrange path elements the other way around

### DIFF
--- a/crates/hexora_io/src/lib.rs
+++ b/crates/hexora_io/src/lib.rs
@@ -184,7 +184,7 @@ mod tests {
                 assert!(file.archive_path.as_ref().unwrap().ends_with("test.zip"));
                 assert_eq!(
                     file.full_path(),
-                    format!("inner.py:{}", archive_path.display())
+                    format!("{}:inner.py", archive_path.display())
                 );
                 found_zip_py = true;
             }


### PR DESCRIPTION
The `inner.py` needs to be appended to the archive path, not prepended.

Fixes the failing CI in #3.
